### PR TITLE
onboarding: impl frame extraction and audio extraction

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,8 +14,28 @@ def extract_frames(video_path: str, output_folder: str, interval: int):
     Returns:
         None
     """
-    # Your code starts here...
-    pass
+    os.makedirs(output_folder, exist_ok=True)
+    
+    cap = cv2.VideoCapture(video_path)
+    fps = cap.get(cv2.CAP_PROP_FPS)
+    f_interval = int(fps * interval)  # calculate frames to skip based on time interval
+    
+    f_count = saved_count = 0
+    
+    # check if frames exist without loading pixel data
+    while cap.read()[0]:
+        if f_count % f_interval == 0:
+            # seek to specific frame position to avoid loading unwanted frames
+            cap.set(cv2.CAP_PROP_POS_FRAMES, f_count)
+            ret, frame = cap.read()
+            if ret:
+                # 04d ensures consistent filename sorting (frame_0001.jpg, frame_0002.jpg, etc.)
+                cv2.imwrite(f"{output_folder}/frame_{saved_count:04d}.jpg", frame)
+                saved_count += 1
+        f_count += 1
+    
+    # clean up video capture 
+    cap.release()
 
 
 def extract_audio(video_path: str, output_path: str):
@@ -29,9 +49,15 @@ def extract_audio(video_path: str, output_path: str):
     Returns:
         None
     """
-    # Your code starts here...
-    pass
-
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    
+    # use uncompressed PCM for lossless audio extraction: 
+    #   pcm_s16le: 16-bit signed little-endian (standard for WAV)
+    #   ar='44100': 44.1kHz sample rate (CD quality)
+    #   ac=2: stereo output (2 channels)
+    ffmpeg.input(video_path).output(
+        output_path, acodec='pcm_s16le', ar='44100', ac=2  
+    ).overwrite_output().run(quiet=True)
 
 # ------------- DO NOT MODIFY BELOW -------------
 

--- a/main.py
+++ b/main.py
@@ -17,25 +17,29 @@ def extract_frames(video_path: str, output_folder: str, interval: int):
     os.makedirs(output_folder, exist_ok=True)
     
     cap = cv2.VideoCapture(video_path)
+    if not cap.isOpened():
+        raise ValueError(f"Cannot open video file: {video_path}")
+    
     fps = cap.get(cv2.CAP_PROP_FPS)
     f_interval = int(fps * interval)  # calculate frames to skip based on time interval
     
     f_count = saved_count = 0
     
-    # check if frames exist without loading pixel data
-    while cap.read()[0]:
-        if f_count % f_interval == 0:
-            # seek to specific frame position to avoid loading unwanted frames
-            cap.set(cv2.CAP_PROP_POS_FRAMES, f_count)
-            ret, frame = cap.read()
-            if ret:
-                # 04d ensures consistent filename sorting (frame_0001.jpg, frame_0002.jpg, etc.)
-                cv2.imwrite(f"{output_folder}/frame_{saved_count:04d}.jpg", frame)
-                saved_count += 1
-        f_count += 1
-    
-    # clean up video capture 
-    cap.release()
+    try:
+        # check if frames exist without loading pixel data
+        while cap.read()[0]:
+            if f_count % f_interval == 0:
+                # seek to specific frame position to avoid loading unwanted frames
+                cap.set(cv2.CAP_PROP_POS_FRAMES, f_count)
+                ret, frame = cap.read()
+                if ret:
+                    # 04d ensures consistent filename sorting (frame_0001.jpg, frame_0002.jpg, etc.)
+                    cv2.imwrite(f"{output_folder}/frame_{saved_count:04d}.jpg", frame)
+                    saved_count += 1
+            f_count += 1
+    finally:
+        # clean up video capture 
+        cap.release()
 
 
 def extract_audio(video_path: str, output_path: str):
@@ -51,13 +55,16 @@ def extract_audio(video_path: str, output_path: str):
     """
     os.makedirs(os.path.dirname(output_path), exist_ok=True)
     
-    # use uncompressed PCM for lossless audio extraction: 
-    #   pcm_s16le: 16-bit signed little-endian (standard for WAV)
-    #   ar='44100': 44.1kHz sample rate (CD quality)
-    #   ac=2: stereo output (2 channels)
-    ffmpeg.input(video_path).output(
-        output_path, acodec='pcm_s16le', ar='44100', ac=2  
-    ).overwrite_output().run(quiet=True)
+    try:
+        # use uncompressed PCM for lossless audio extraction: 
+        #   pcm_s16le: 16-bit signed little-endian (standard for WAV)
+        #   ar='44100': 44.1kHz sample rate (CD quality)
+        #   ac=2: stereo output (2 channels)
+        ffmpeg.input(video_path).output(
+            output_path, acodec='pcm_s16le', ar='44100', ac=2  
+        ).overwrite_output().run(quiet=True)
+    except ffmpeg.Error as e:
+        raise RuntimeError(f"Audio extraction failed: {e}")
 
 # ------------- DO NOT MODIFY BELOW -------------
 


### PR DESCRIPTION
`extract_frames()`: Takes video input and extracts frames at specified intervals using OpenCV. Uses `cv2.VideoCapture` to open the video, `cv2.CAP_PROP_FPS` to calculate frame intervals, and `cap.read()` to efficiently check for frame existence. Saves frames with consistent naming to the output folder.

`extract_audio()`: Uses `ffmpeg` to extract lossless audio from video files. Outputs 16-bit PCM (WAV) audio with `ffmpeg.input().output().run()`, forcing stereo (`ac=2`) and a 44.1kHz sample rate (`ar='44100'`).
